### PR TITLE
Dt/heartbeat changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
 gem "chef", "~> 11.6.2"
-gem "zmq", "~> 2.1.4"
+gem "zmq", :git => "git@github.com:opscode/rbzmq.git"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source :rubygems
 
+gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 gem "chef", "~> 11.6.2"
 gem "zmq", :git => "git@github.com:opscode/rbzmq.git"
 

--- a/spec/pushy/support/end_to_end_util.rb
+++ b/spec/pushy/support/end_to_end_util.rb
@@ -68,6 +68,8 @@ shared_context "end_to_end_util" do
       )
       @clients[name][:client] = new_client
       @clients[name][:client].start
+      # Override the splay configuration to speed up reconfigure and avoid timeouts:
+      @clients[name][:client].config['push_jobs']['reconfigure_splay'] = 1
     end
 
     names.each do |name|

--- a/spec/pushy/support/end_to_end_util.rb
+++ b/spec/pushy/support/end_to_end_util.rb
@@ -81,6 +81,7 @@ shared_context "end_to_end_util" do
     end
 
     begin
+      offline_nodes = nil;
       Timeout::timeout(5) do
         while true
           offline_nodes = names.select { |name| !@clients[name][:client].online? }


### PR DESCRIPTION
Updated the gemfile to use the latest rbzmq repo, and updated the client setup to override the new splay setting for reconfigure after the ZMQ connection is broken so that reconfigure happens quickly and tests don't timeout.
