### PR TITLE
Update chef version to match push jobs client;

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 # on.
 gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :tag => '1.0.28'
 gem 'oc-chef-pedant', :git => "git@github.com:opscode/oc-chef-pedant.git", :tag => '1.0.28'
-gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :tag => '1.0.1'
+gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :branch => 'ma/use-ffi-rzmq'

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,17 @@
 source :rubygems
 
-gem "chef", "~> 11.6.2"
+gem "chef", "~> 11.12.2"
 gem "zmq", "~> 2.1.4"
 
 gemspec
+
+# For some unknown reason we seem to not pick this up from our dependencies
+gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 
 # Even though chef-pedant is a dependency of oc-chef-pedant, the gem
 # is not on RubyGems, so we have to lock the dependency here, too.  It
 # should be whatever the specified version of oc-chef-pedant depends
 # on.
-gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :tag => '1.0.22'
-gem 'oc-chef-pedant', :git => "git@github.com:opscode/oc-chef-pedant.git", :tag => '1.0.20'
-gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :tag => '1.0.0'
+gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :tag => '1.0.28'
+gem 'oc-chef-pedant', :git => "git@github.com:opscode/oc-chef-pedant.git", :tag => '1.0.28'
+gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :tag => '1.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
 gem "chef", "~> 11.12.2"
-gem "zmq", "~> 2.1.4"
+gem "ffi-rzmq"
 
 gemspec
 
@@ -12,6 +12,6 @@ gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 # is not on RubyGems, so we have to lock the dependency here, too.  It
 # should be whatever the specified version of oc-chef-pedant depends
 # on.
-gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :tag => '1.0.28'
-gem 'oc-chef-pedant', :git => "git@github.com:opscode/oc-chef-pedant.git", :tag => '1.0.28'
-gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :tag => '1.0.1'
+gem 'chef-pedant', :path => '/srv/piab/mounts/chef-pedant'
+gem 'oc-chef-pedant', :path => '/srv/piab/mounts/oc-chef-pedant'
+gem 'opscode-pushy-client', :path => '/srv/piab/mounts/opscode-pushy-client'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 # is not on RubyGems, so we have to lock the dependency here, too.  It
 # should be whatever the specified version of oc-chef-pedant depends
 # on.
-gem 'chef-pedant', :path => '/srv/piab/mounts/chef-pedant'
-gem 'oc-chef-pedant', :path => '/srv/piab/mounts/oc-chef-pedant'
-gem 'opscode-pushy-client', :path => '/srv/piab/mounts/opscode-pushy-client'
+gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :tag => '1.0.28'
+gem 'oc-chef-pedant', :git => "git@github.com:opscode/oc-chef-pedant.git", :tag => '1.0.28'
+gem 'opscode-pushy-client', :git => "git@github.com:opscode/opscode-pushy-client.git", :tag => '1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,10 @@ GIT
       netrc (~> 0.7.7)
       rdoc (>= 2.4.2)
 
-PATH
-  remote: .
-  specs:
-    oc-pushy-pedant (0.0.1)
-
-PATH
-  remote: /srv/piab/mounts/chef-pedant
+GIT
+  remote: git@github.com:opscode/chef-pedant.git
+  revision: 429254b292c77c56b5abdb5f2d465a1dda7e58b5
+  tag: 1.0.28
   specs:
     chef-pedant (1.0.27)
       activesupport (~> 3.2.8)
@@ -27,19 +24,28 @@ PATH
       rspec-rerun (= 0.1.1)
       rspec_junit_formatter (~> 0.1.1)
 
-PATH
-  remote: /srv/piab/mounts/oc-chef-pedant
+GIT
+  remote: git@github.com:opscode/oc-chef-pedant.git
+  revision: 6036b0e98a023c884960356a98a4c436250a063e
+  tag: 1.0.28
   specs:
-    oc-chef-pedant (1.0.29)
+    oc-chef-pedant (1.0.28)
       chef-pedant (>= 1.0.0)
 
-PATH
-  remote: /srv/piab/mounts/opscode-pushy-client
+GIT
+  remote: git@github.com:opscode/opscode-pushy-client.git
+  revision: 64fc931ff36c4b0870d1f4ddfbeedba3e978d8bd
+  branch: ma/use-ffi-rzmq
   specs:
     opscode-pushy-client (1.0.2)
       chef (>= 11.12.2)
       ffi-rzmq
       uuidtools
+
+PATH
+  remote: .
+  specs:
+    oc-pushy-pedant (0.0.1)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,13 @@ GIT
       netrc (~> 0.7.7)
       rdoc (>= 2.4.2)
 
-GIT
-  remote: git@github.com:opscode/chef-pedant.git
-  revision: 429254b292c77c56b5abdb5f2d465a1dda7e58b5
-  tag: 1.0.28
+PATH
+  remote: .
+  specs:
+    oc-pushy-pedant (0.0.1)
+
+PATH
+  remote: /srv/piab/mounts/chef-pedant
   specs:
     chef-pedant (1.0.27)
       activesupport (~> 3.2.8)
@@ -24,37 +27,28 @@ GIT
       rspec-rerun (= 0.1.1)
       rspec_junit_formatter (~> 0.1.1)
 
-GIT
-  remote: git@github.com:opscode/oc-chef-pedant.git
-  revision: 6036b0e98a023c884960356a98a4c436250a063e
-  tag: 1.0.28
+PATH
+  remote: /srv/piab/mounts/oc-chef-pedant
   specs:
-    oc-chef-pedant (1.0.28)
+    oc-chef-pedant (1.0.29)
       chef-pedant (>= 1.0.0)
 
-GIT
-  remote: git@github.com:opscode/opscode-pushy-client.git
-  revision: 3341513f2fa69c659c1377410d30f2b289322a2c
-  tag: 1.0.1
-  specs:
-    opscode-pushy-client (1.0.1)
-      chef (>= 0.10.12)
-      uuidtools
-      zmq
-
 PATH
-  remote: .
+  remote: /srv/piab/mounts/opscode-pushy-client
   specs:
-    oc-pushy-pedant (0.0.1)
+    opscode-pushy-client (1.0.2)
+      chef (>= 11.12.2)
+      ffi-rzmq
+      uuidtools
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.17)
+    activesupport (3.2.18)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     builder (3.2.2)
-    chef (11.12.2)
+    chef (11.12.4)
       chef-zero (~> 2.0, >= 2.0.2)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -68,7 +62,7 @@ GEM
       mixlib-shellout (~> 1.4)
       net-ssh (~> 2.6)
       net-ssh-multi (~> 1.1)
-      ohai (~> 7.0)
+      ohai (~> 7.0.4)
       pry (~> 0.9)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
@@ -80,6 +74,11 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    ffi (1.9.3)
+    ffi-rzmq (2.0.1)
+      ffi-rzmq-core (>= 1.0.1)
+    ffi-rzmq-core (1.0.3)
+      ffi (~> 1.9)
     hashie (2.1.1)
     highline (1.6.21)
     i18n (0.6.9)
@@ -89,20 +88,20 @@ GEM
     mime-types (1.25.1)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.4.0)
+    mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (1.4.0)
-    multi_json (1.9.2)
+    multi_json (1.10.0)
     net-http-spy (0.2.1)
-    net-ssh (2.8.0)
+    net-ssh (2.9.0)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.2.0)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     netrc (0.7.7)
-    ohai (7.0.2)
+    ohai (7.0.4)
       ipaddress
       mime-types (~> 1.16)
       mixlib-cli
@@ -136,7 +135,6 @@ GEM
     systemu (2.5.2)
     uuidtools (2.1.4)
     yajl-ruby (1.2.0)
-    zmq (2.1.4)
 
 PLATFORMS
   ruby
@@ -144,8 +142,8 @@ PLATFORMS
 DEPENDENCIES
   chef (~> 11.12.2)
   chef-pedant!
+  ffi-rzmq
   oc-chef-pedant!
   oc-pushy-pedant!
   opscode-pushy-client!
   rest-client!
-  zmq (~> 2.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,43 @@
 GIT
-  remote: git@github.com:opscode/chef-pedant.git
-  revision: be24c567600570679a5d801b0d601d07ebabb312
-  tag: 1.0.22
+  remote: git://github.com/opscode/rest-client.git
+  revision: ba0d12258b77791d8f7d9776d008eb6fa3580ccc
   specs:
-    chef-pedant (1.0.22)
+    rest-client (1.7.0.alpha)
+      mime-types (>= 1.16)
+      netrc (~> 0.7.7)
+      rdoc (>= 2.4.2)
+
+GIT
+  remote: git@github.com:opscode/chef-pedant.git
+  revision: 429254b292c77c56b5abdb5f2d465a1dda7e58b5
+  tag: 1.0.28
+  specs:
+    chef-pedant (1.0.27)
       activesupport (~> 3.2.8)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
-      mixlib-config (~> 1.1.2)
-      mixlib-shellout (~> 1.1.0)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 1.1)
       net-http-spy (~> 0.2.1)
-      rest-client (~> 1.6.7)
-      rspec (~> 2.11.0)
+      rest-client (= 1.7.0.alpha)
+      rspec (~> 2.11)
       rspec-rerun (= 0.1.1)
       rspec_junit_formatter (~> 0.1.1)
 
 GIT
   remote: git@github.com:opscode/oc-chef-pedant.git
-  revision: 061b8d66c559f183ab2f0e572da9d1349be8635c
-  tag: 1.0.20
+  revision: 6036b0e98a023c884960356a98a4c436250a063e
+  tag: 1.0.28
   specs:
-    oc-chef-pedant (1.0.20)
+    oc-chef-pedant (1.0.28)
       chef-pedant (>= 1.0.0)
 
 GIT
   remote: git@github.com:opscode/opscode-pushy-client.git
-  revision: 6fd222bfc159bc1154f1658defe4f04eb6d95fb2
-  tag: 1.0.0
+  revision: 3341513f2fa69c659c1377410d30f2b289322a2c
+  tag: 1.0.1
   specs:
-    opscode-pushy-client (0.0.1)
+    opscode-pushy-client (1.0.1)
       chef (>= 0.10.12)
       uuidtools
       zmq
@@ -41,81 +50,102 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.15)
+    activesupport (3.2.17)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     builder (3.2.2)
-    chef (11.6.2)
+    chef (11.12.2)
+      chef-zero (~> 2.0, >= 2.0.2)
+      diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
       highline (~> 1.6, >= 1.6.9)
-      json (>= 1.4.4, <= 1.7.7)
+      json (>= 1.4.4, <= 1.8.1)
+      mime-types (~> 1.16)
       mixlib-authentication (~> 1.3)
-      mixlib-cli (~> 1.3)
-      mixlib-config (~> 1.1, >= 1.1.2)
+      mixlib-cli (~> 1.4)
+      mixlib-config (~> 2.0)
       mixlib-log (~> 1.3)
-      mixlib-shellout (~> 1.1)
+      mixlib-shellout (~> 1.4)
       net-ssh (~> 2.6)
-      net-ssh-multi (~> 1.1.0)
-      ohai (>= 0.6.0, < 7.0.0)
+      net-ssh-multi (~> 1.1)
+      ohai (~> 7.0)
+      pry (~> 0.9)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
-    diff-lcs (1.1.3)
+    chef-zero (2.0.2)
+      hashie (~> 2.0)
+      json
+      mixlib-log (~> 1.3)
+      rack
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
-    highline (1.6.20)
-    i18n (0.6.5)
+    hashie (2.1.1)
+    highline (1.6.21)
+    i18n (0.6.9)
     ipaddress (0.8.0)
-    json (1.7.7)
-    mime-types (1.25)
+    json (1.8.1)
+    method_source (0.8.2)
+    mime-types (1.25.1)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.3.0)
-    mixlib-config (1.1.2)
+    mixlib-cli (1.4.0)
+    mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.1.0)
-    multi_json (1.8.2)
+    mixlib-shellout (1.4.0)
+    multi_json (1.9.2)
     net-http-spy (0.2.1)
-    net-ssh (2.7.0)
+    net-ssh (2.8.0)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    net-ssh-multi (1.1)
-      net-ssh (>= 2.1.4)
-      net-ssh-gateway (>= 0.99.0)
-    ohai (6.18.0)
+    net-ssh-multi (1.2.0)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    netrc (0.7.7)
+    ohai (7.0.2)
       ipaddress
+      mime-types (~> 1.16)
       mixlib-cli
-      mixlib-config
+      mixlib-config (~> 2.0)
       mixlib-log
-      mixlib-shellout
-      systemu
+      mixlib-shellout (~> 1.2)
+      systemu (~> 2.5.2)
       yajl-ruby
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rack (1.5.2)
+    rdoc (4.1.1)
+      json (~> 1.4)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
     rspec-rerun (0.1.1)
       rspec (>= 2.11.0)
     rspec_junit_formatter (0.1.6)
       builder
       rspec (~> 2.0)
       rspec-core (!= 2.12.0)
+    slop (3.5.0)
     systemu (2.5.2)
     uuidtools (2.1.4)
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.2.0)
     zmq (2.1.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  chef (~> 11.6.2)
+  chef (~> 11.12.2)
   chef-pedant!
   oc-chef-pedant!
   oc-pushy-pedant!
   opscode-pushy-client!
+  rest-client!
   zmq (~> 2.1.4)

--- a/spec/pushy/integration/config_spec.rb
+++ b/spec/pushy/integration/config_spec.rb
@@ -33,7 +33,8 @@ describe "pushy config" do
   end
 
   let(:pushy_server) {
-    Pedant.config[:pushy_server]
+    # We don't actually provide pushy_server in our current config file
+    Pedant.config[:pushy_server] || URI(Pedant.config[:chef_server]).host 
   }
 
   # TODO: should get this from config instead of hard-coding
@@ -176,7 +177,7 @@ describe "pushy config" do
       end
 
       it 'returns a 200 ("OK") for client' do
-        get(api_url("/pushy/config/pedant_non_admin_client"),
+        get(api_url("/pushy/config/#{platform.non_admin_client.name}"),
             platform.non_admin_client) do |response|
           response.should look_like({
                                       :status => 200


### PR DESCRIPTION
Updates to the rest of the locked deps to avoid chef version conflicts.

@jkeiser @christophermaier 