### PR TITLE
push-setup script for aiding manual testing

### DIFF
--- a/dev/push-setup/.gitignore
+++ b/dev/push-setup/.gitignore
@@ -1,0 +1,19 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml
+
+test/integration/nodes/
+.chef

--- a/dev/push-setup/.kitchen.yml
+++ b/dev/push-setup/.kitchen.yml
@@ -1,0 +1,32 @@
+---
+driver:
+  name: vagrant
+  forward_agent: yes
+  customize:
+      memory: 2048
+      cpus: 2
+      natdnshostresolver1: "on"
+      natdnsproxy1: "on"
+      nictype1: "virtio"
+  network:
+    - [ 'private_network', {type: 'dhcp'} ]
+  synced_folders:
+    - ['./.chef/', '/srv']
+    - ['.', '/vagrant']
+
+provisioner:
+  name: nodes
+  require_chef_omnibus: true
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: server
+    run_list:
+      - recipe[push-setup::server]
+    attributes:
+  - name: client
+    run_list:
+      - recipe[push-setup::client]
+    attributes:

--- a/dev/push-setup/Berksfile
+++ b/dev/push-setup/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/dev/push-setup/Gemfile
+++ b/dev/push-setup/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'kitchen-nodes'
+gem 'knife-push'

--- a/dev/push-setup/README.md
+++ b/dev/push-setup/README.md
@@ -1,0 +1,35 @@
+# push-setup
+
+Sets up push-server and push-client cluster via test-kitchen to help make manual testing a little quicker.
+
+To use this you need Vagrant >= 1.8.1 and a recent ChefDK.
+
+From this directory:
+
+    bundle install
+
+    ./push-setup
+
+When setup completes, verify that the push cluster is working:
+
+    $ knife node status client
+    client  available
+
+    $ knife job start chef-client client
+    Started.  Job ID: 29ec910c2a3f040aeebb07c398d93d9e
+    .Running (1/1 in progress) ...
+    ...Complete.
+    command:     chef-client
+    created_at:  Wed, 11 May 2016 15:14:35 GMT
+    env:
+    id:          29ec910c2a3f040aeebb07c398d93d9e
+    nodes:
+      succeeded: client
+    run_timeout: 3600
+    status:      complete
+    updated_at:  Wed, 11 May 2016 15:14:39 GMT
+
+## TODO
+
+- Allow the platforms to be configurable (currently hardcoded to ubuntu-14.04 for server and client)
+- Allow the push-client and push-server versions to be configurable (currently hardcoded to :current)

--- a/dev/push-setup/chefignore
+++ b/dev/push-setup/chefignore
@@ -1,0 +1,102 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/dev/push-setup/metadata.rb
+++ b/dev/push-setup/metadata.rb
@@ -1,0 +1,12 @@
+name 'push-setup'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+description 'Installs/Configures push-setup'
+long_description 'Installs/Configures push-setup'
+version '0.1.0'
+
+depends 'chef-ingredient'
+depends 'push-jobs'
+depends 'hostsfile'
+depends 'hurry-up-and-test'

--- a/dev/push-setup/push-client.json
+++ b/dev/push-setup/push-client.json
@@ -1,0 +1,11 @@
+{
+  "push_jobs": {
+    "package_url": "http://artifactory.chef.co/simple/omnibus-current-local/com/getchef/push-jobs-client/2.1.0+20160509080113/ubuntu/14.04/push-jobs-client_2.1.0+20160509080113-1_amd64.deb",
+    "package_checksum": "d8bdab970166019499e689c0cdd702fa9ca03913dc7371a4bebf75d5e2151c35",
+    "package_version": "2.0.0-alpha",
+    "chef": {
+      "verify_api_cert": false,
+      "ssl_verify_mode": "verify_none"
+    }
+  }
+}

--- a/dev/push-setup/push-setup
+++ b/dev/push-setup/push-setup
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+WORKSPACE_DIR=.chef
+
+setup_workspace() {
+    echo -n "Setting up workspace. "
+    mkdir -p $WORKSPACE_DIR
+    echo "Done."
+}
+
+setup_server() {
+    echo "Setting up server VM."
+    kitchen converge server
+    echo "Done."
+}
+
+setup_client() {
+    echo "Setting up client VM."
+    kitchen converge client
+    echo "Done."
+}
+
+bootstrap_client() {
+    echo "Bootstrapping client node."
+    berks install
+    berks upload --no-ssl-verify
+    knife bootstrap "$(< $WORKSPACE_DIR/client-ip)" \
+        -r 'recipe[push-jobs]' --json-attribute-file 'push-client.json' \
+        -x vagrant -P vagrant --sudo --node-name client \
+        --node-ssl-verify-mode none
+    echo "Done."
+}
+
+setup() {
+    setup_workspace
+    setup_server
+    setup_client
+    bootstrap_client
+    echo "Setup complete. Run 'kitchen destroy' to clean up."
+}
+
+setup

--- a/dev/push-setup/recipes/client.rb
+++ b/dev/push-setup/recipes/client.rb
@@ -1,0 +1,17 @@
+include_recipe 'hurry-up-and-test::set_non_nat_vbox_ip'
+
+Chef::Log.warn("Node fqdn: #{node['fqdn']}")
+Chef::Log.warn("Node ipaddress: #{node['ipaddress']}")
+
+search(:node, 'fqdn:server-*') do |n|
+  hostsfile_entry n['ipaddress'] do
+    hostname n['fqdn']
+    action :create
+  end
+end
+
+file '/srv/client-ip' do
+  content node['ipaddress']
+end
+
+# include_recipe 'push-jobs'

--- a/dev/push-setup/recipes/server.rb
+++ b/dev/push-setup/recipes/server.rb
@@ -1,0 +1,63 @@
+include_recipe 'hurry-up-and-test::set_non_nat_vbox_ip'
+
+Chef::Log.warn("Node fqdn: #{node['fqdn']}")
+Chef::Log.warn("Node ipaddress: #{node['ipaddress']}")
+
+chef_ingredient 'chef-server' do
+  config <<-EOS
+api_fqdn '#{node['fqdn']}'
+EOS
+end
+
+ingredient_config 'chef-server' do
+  notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
+end
+
+chef_ingredient 'manage' do
+  accept_license true
+  action :install
+end
+
+ingredient_config 'manage' do
+  notifies :reconfigure, 'chef_ingredient[manage]'
+end
+
+chef_ingredient 'push-jobs-server' do
+  channel :current
+  accept_license true
+  action :install
+end
+
+ingredient_config 'push-jobs-server' do
+  notifies :reconfigure, 'chef_ingredient[push-jobs-server]'
+end
+
+execute 'create admin' do
+  command <<-EOF.gsub(/\s+/, ' ').strip!
+    chef-server-ctl user-create
+      admin
+      Adam Admin
+      cheffio@chef.io
+      none11
+      --filename #{File.join('/srv', 'admin.pem')}
+  EOF
+  not_if 'chef-server-ctl user-show admin'
+  notifies :run, 'execute[create org]', :immediately
+end
+
+execute 'create org' do
+  command <<-EOF.gsub(/\s+/, ' ').strip!
+    chef-server-ctl org-create
+    admin-org
+    'Delightful Development Organization'
+    --association_user admin
+    --filename #{File.join('/srv', 'admin-validator.pem')}
+  EOF
+  action :nothing
+end
+
+template "/srv/knife.rb" do
+   source "knife.rb.erb"
+   variables(server_url: node['ipaddress'])
+   action :create
+end

--- a/dev/push-setup/spec/spec_helper.rb
+++ b/dev/push-setup/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/dev/push-setup/spec/unit/recipes/default_spec.rb
+++ b/dev/push-setup/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: push-setup
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'push-setup::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/dev/push-setup/templates/knife.rb.erb
+++ b/dev/push-setup/templates/knife.rb.erb
@@ -1,0 +1,9 @@
+current_dir = File.dirname(__FILE__)
+log_level                :info
+log_location             STDOUT
+node_name                "admin"
+client_key               "#{current_dir}/admin.pem"
+validation_client_name   "admin-validator"
+validation_key           "#{current_dir}/admin-org-validator.pem"
+chef_server_url          "https://<%= @server_url %>/organizations/admin-org"
+ssl_verify_mode          :verify_none

--- a/dev/push-setup/test/integration/default/serverspec/default_spec.rb
+++ b/dev/push-setup/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'push-setup::default' do
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+  it 'does something' do
+    skip 'Replace this with meaningful tests'
+  end
+end

--- a/dev/push-setup/test/integration/helpers/serverspec/spec_helper.rb
+++ b/dev/push-setup/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
+  set :backend, :exec
+else
+  set :backend, :cmd
+  set :os, family: 'windows'
+end


### PR DESCRIPTION
This is the start of a simple script + cookbook for setting up
a push-server and push-client cluster to help make manual push-jobs
testing a little quicker. It has similar goals to [analytics-setup](https://github.com/chef/chef-analytics/tree/master/dev/cookbooks/analytics-setup).

It uses `test-kitchen` and `knife` to stand up a chef-server VM
that has push-jobs-server installed and configured on it and then
also a chef-client VM that has the push-client installed and
configured on it.

This was a timeboxed effort so there are further improvements that
should/need to be made in the near future in order to get more utility
out of this script.

--

Run `./push-setup` from `dev/push-setup`.

When setup completes, verify that the push cluster is working:

    $ knife node status client
    client  available


    $ knife job start chef-client client
    Started.  Job ID: 29ec910c2a3f040aeebb07c398d93d9e
    .Running (1/1 in progress) ...
    ...Complete.
    command:     chef-client
    created_at:  Wed, 11 May 2016 15:14:35 GMT
    env:
    id:          29ec910c2a3f040aeebb07c398d93d9e
    nodes:
      succeeded: client
    run_timeout: 3600
    status:      complete
    updated_at:  Wed, 11 May 2016 15:14:39 GMT

TODO:

- Allow the platforms to be configurable (currently hardcoded to ubuntu-14.04 for server and client)
- Allow the push-client and push-server versions to be configurable (currently hardcoded to :current)